### PR TITLE
improve benchmark

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,18 +2,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::panic;
-use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use pixelfmt::{
-    frame::{ConsecutiveFrame, Frame, FrameMut},
-    PixelFormat,
-};
+use pixelfmt::frame::{ConsecutiveFrame, Frame, FrameMut};
 
 /// Reads and writes about the right amount of stuff with `memcpy`.
 ///
 /// This produces nonsense; it's useful only as a memory bandwidth baseline.
-fn memcpy_baseline<FI: Frame, FO: FrameMut>(input: &FI, output: &mut FO) {
+fn memcpy_baseline(input: &ConsecutiveFrame<Vec<u8>>, output: &mut ConsecutiveFrame<Vec<u8>>) {
     assert!(input.initialized());
     let input_planes = input.planes();
     let [input] = &input_planes[..] else {
@@ -90,8 +86,12 @@ fn bench_common<const FRAMES_PER_ITER: usize>(
 ) {
     const WIDTH: usize = 1920;
     const HEIGHT: usize = 1080;
-    let inputs: [_; FRAMES_PER_ITER] = std::array::from_fn(|_| {
-        ConsecutiveFrame::new(pixelfmt::PixelFormat::UYVY422, WIDTH, HEIGHT).with_storage(
+    struct Operation {
+        input: ConsecutiveFrame<Vec<u8>>,
+        output: ConsecutiveFrame<Vec<u8>>,
+    }
+    let mut ops: [Operation; FRAMES_PER_ITER] = std::array::from_fn(|_| Operation {
+        input: ConsecutiveFrame::new(pixelfmt::PixelFormat::UYVY422, WIDTH, HEIGHT).with_storage(
             // This dummy frame is filled with 1s rather than 0s so that it has
             // to occupy distinct physical memory rather than take advantage of
             // the zero page optimization on Linux. [1] Distinct physical memory
@@ -99,60 +99,61 @@ fn bench_common<const FRAMES_PER_ITER: usize>(
             //
             // [1] https://lwn.net/Articles/517465/
             vec![1u8; WIDTH * HEIGHT * 2],
-        )
+        ),
+        output: ConsecutiveFrame::new(pixelfmt::PixelFormat::I420, WIDTH, HEIGHT).new_vec(),
     });
     g.throughput(criterion::Throughput::Bytes(
-        (inputs.len() * (WIDTH * HEIGHT * 7) / 2) as u64,
+        ((WIDTH * HEIGHT * 7) / 2) as u64,
     ));
-    macro_rules! bench_block {
-        ($name:literal, $p:expr) => {
-            let p = $p;
+    macro_rules! bench {
+        ($name:literal, $f:expr) => {
             g.bench_function($name, |b| {
-                b.iter(|| {
-                    for i in &inputs {
-                        let mut f =
-                            ConsecutiveFrame::new(PixelFormat::I420, WIDTH, HEIGHT).new_vec();
-                        black_box(convert_with(p, i, &mut f).unwrap());
+                b.iter_custom(|iters| {
+                    let start = std::time::Instant::now();
+                    for _ in 0..iters {
+                        for op in &mut ops {
+                            $f(op);
+                        }
                     }
-                })
+                    start.elapsed() / FRAMES_PER_ITER as u32
+                });
             });
         };
     }
+    macro_rules! bench_block {
+        ($name:literal, $p:expr) => {
+            let p = $p;
+            bench!($name, |op: &mut Operation| convert_with(
+                p,
+                &op.input,
+                &mut op.output
+            )
+            .unwrap());
+        };
+    }
     use pixelfmt::uyvy_to_i420::*;
-    g.bench_function("memcpy_baseline", |b| {
-        b.iter(|| {
-            for i in &inputs {
-                black_box(memcpy_baseline(
-                    i,
-                    &mut ConsecutiveFrame::new(PixelFormat::I420, WIDTH, HEIGHT).new_vec(),
-                ));
-            }
-        })
-    });
-    g.bench_function("libyuv", |b| {
-        b.iter(|| {
-            for i in &inputs {
-                black_box(libyuv(
-                    i,
-                    &mut ConsecutiveFrame::new(PixelFormat::I420, WIDTH, HEIGHT).new_vec(),
-                ));
-            }
-        })
-    });
+    bench!("memcpy_baseline", |op: &mut Operation| memcpy_baseline(
+        &op.input,
+        &mut op.output
+    ));
+    bench!("libyuv", |op: &mut Operation| libyuv(
+        &op.input,
+        &mut op.output
+    ));
     #[cfg(target_arch = "x86_64")]
-    bench_block!(
-        "explicit_avx2_double",
-        ExplicitAvx2DoubleBlock::try_new().unwrap()
-    );
-    #[cfg(target_arch = "x86_64")]
-    bench_block!(
-        "explicit_avx2_single",
-        ExplicitAvx2SingleBlock::try_new().unwrap()
-    );
+    if is_x86_feature_detected!("avx2") {
+        bench_block!(
+            "explicit_avx2_double",
+            ExplicitAvx2DoubleBlock::try_new().unwrap()
+        );
+        bench_block!(
+            "explicit_avx2_single",
+            ExplicitAvx2SingleBlock::try_new().unwrap()
+        );
+        bench_block!("auto_avx2_64", AutoAvx2Block::<64>::try_new().unwrap());
+    }
     #[cfg(target_arch = "x86_64")]
     bench_block!("explicit_sse2", ExplicitSse2::new());
-    #[cfg(target_arch = "x86_64")]
-    bench_block!("auto_avx2_64", AutoAvx2Block::<64>::try_new().unwrap());
     #[cfg(target_arch = "aarch64")]
     bench_block!("explicit_neon", ExplicitNeon::try_new().unwrap());
     #[cfg(target_arch = "aarch64")]
@@ -166,7 +167,7 @@ fn bench_common<const FRAMES_PER_ITER: usize>(
 
 /// Cold benchmark: each iteration processes enough data to be unlikely to fit in cache.
 fn bench_cold(c: &mut Criterion) {
-    bench_common::<32>(c.benchmark_group("cold"));
+    bench_common::<128>(c.benchmark_group("cold"));
 }
 
 /// Hot benchmark: each iteration operates on a single frame that likely fits in the CPU's LLC.


### PR DESCRIPTION
Before, this was allocating/deallocating each output frame before proceeding to the next. That was bad in two ways:

* it doesn't focus on this crate's actual work
* if the memory allocator hands out the same memory region next time, the "cold" benchmarks aren't really using cold memory on the output side.

Also, use criterion's `iter_custom` so that it sees the time per single operation, not per group.