### PR TITLE
prep for releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,52 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 keywords = ["yuv"]
 categories = ["multimedia::images", "multimedia::video"]
 repository = "https://github.com/infiniteathlete/pixelfmt"
+rust-version = "1.79"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 keywords = ["yuv"]
 categories = ["multimedia::images", "multimedia::video"]
+repository = "https://github.com/infiniteathlete/pixelfmt"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pixelfmt
 
+[![crates.io](https://img.shields.io/crates/v/pixelfmt.svg)](https://crates.io/crates/pixelfmt)
+[![docs.rs](https://img.shields.io/docsrs/pixelfmt)](https://docs.rs/pixelfmt)
+[![CI](https://img.shields.io/github/actions/workflow/status/infiniteathlete/pixelfmt/push.yml?branch=main)](https://github.com/infiniteathlete/pixelfmt/actions/workflows/push.yml)
+
 Pixel format conversions in pure Rust with SIMD optimizations on x86\_64 and
 aarch64. The performance goal is to approximately reach the memory bandwidth
 limit and thus optimal performance when the input and output are not already


### PR DESCRIPTION
* The `.github/workflows/release-plz.yml` is as created by `release-plz init`; I didn't alter it at all. It's supposed to open a release PR when anything changes, update it as more changes come in, then actually do a release when I merge the PR. It uses crates.io and GitHub PAT tokens that I've scoped to the repo and the needed permissions.

* Add repository link to the crates.io metadata so folks can find where to file an issue and such.

* Add badges to the README as also generally expected.