### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/infiniteathlete/pixelfmt/compare/v0.2.0...v0.2.1) - 2025-02-27
+
+### Fixed
+
+- offer longer lifetime slice accessors
+
+### Other
+
+- fix clippy 1.85 warning
 # version 0.2.0 (2025-01-10)
 
 * BREAKING: simplified by dropping the concept of an uninitialized frame.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "pixelfmt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrayvec",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixelfmt"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pixel format conversions in pure Rust with SIMD optimizations"
 authors = ["Infinite Athlete, Inc. <av-eng@infiniteathlete.ai>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `pixelfmt`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/infiniteathlete/pixelfmt/compare/v0.2.0...v0.2.1) - 2025-02-27

### Fixed

- offer longer lifetime slice accessors

### Other

- fix clippy 1.85 warning
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).